### PR TITLE
fix(a11y): make the animation accessible

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -80,7 +80,7 @@ button {
 
 @media not (prefers-reduced-motion) {
   .tc_buddy {
-    animation: drive 0.5s ease infinite alternate;
+    animation: drive 0.5s ease 10 alternate;
   }
 }
 

--- a/styles.css
+++ b/styles.css
@@ -76,7 +76,12 @@ button {
   padding: 20px;
   box-sizing: border-box;
   filter: drop-shadow(12px 12px 1px rgb(0, 0, 0, 0.1));
-  animation: drive 0.5s ease infinite alternate;
+}
+
+@media not (prefers-reduced-motion) {
+  .tc_buddy {
+    animation: drive 0.5s ease infinite alternate;
+  }
 }
 
 @keyframes drive {


### PR DESCRIPTION
Animations lasting longer than 5s must have a method for the user to stop, pause, or hide the element. That's my simplified definition of [WCAG Success Criterion 2.2.2: Pause, Stop, Hide (Level A)](https://www.w3.org/WAI/WCAG21/Understanding/pause-stop-hide.html). The easiest way I could come up with to meet this criterion was to make the animation only last for 5s. 

I also added a CSS media query to stop the animation if the user has the prefers reduced motion setting activated. This supports [WCAG SC 2.3.3 Animation from Interactions (Level AAA)](https://www.w3.org/WAI/WCAG21/Understanding/animation-from-interactions.html).