### PR TITLE
improved contrast

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -94,13 +94,13 @@ button {
 }
 
 #mc_embed_signup {
-  background: rgb(251, 156, 22);
+  background:rgb(251, 156, 22);
   max-width: 400px;
   margin: 20px;
   transform: rotate(2deg);
   border: 5px dashed rgb(179, 104, 0);
   padding: 5px;
-  color: white;
+  color: #2c2c2c;
   border-radius: 20px;
   font-size: 14px;
   font-family: Arial, Helvetica, sans-serif;


### PR DESCRIPTION
## Issue
The white text in the email signup box did not have enough contrast as per WCAG accessibility standards.

## Changes proposed 
Improved the contrast between the background and text in the email signup box:
Changed the background color to rgb(251, 156, 22) (orange).
Updated the text color to #2c2c2c (dark grey) for better contrast and accessibility compliance.

## Screenshots
![image](https://github.com/user-attachments/assets/e7ddf118-2755-4b6a-a28e-aa769d89f98f)

