### PR TITLE
Improve footer spacing by adding margin-bottom

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -17,7 +17,9 @@ h4,
   font-family: Helvetica;
   font-weight: 900;
   text-align: center;
-  margin: 0;
+  margin-bottom: 1.5rem;
+  /* margin-bottom: 20px;
+  padding-bottom: 20px; */
 }
 
 /* NAV */


### PR DESCRIPTION
## Fix footer text size and improve spacing

I added `margin-bottom` to the footer for better spacing and layout, making it look more balanced compared to the previous design.

**Issue**: #60

### Before and After

![image](https://github.com/user-attachments/assets/436fb2ae-aee9-4e8d-b16f-717603219a36)


![image](https://github.com/user-attachments/assets/d448e752-51f6-45bf-ab47-f86265d51d6a)

## Checklist

- [x] I have read and agree to the [Code of Conduct].
